### PR TITLE
Implement threaded tweets for price changes that exceed a single-tweet char limit

### DIFF
--- a/pages/api/twitter/index.js
+++ b/pages/api/twitter/index.js
@@ -1,15 +1,14 @@
 /**
  * Endpoint to hit to tweet out price changes, if there are any.
  * Hit by cron job to automate it
-*/
-
-import { tweetPriceChanges } from '../../../util/postPriceChangeTweet'
+ */
+import { tweetPriceChanges } from "../../../util/postPriceChangeTweet";
 
 export default async (req, res) => {
-    await tweetPriceChanges()
-    try {
-        res.status(200).send({ data: 'Tweet Attempted' })
-    } catch (error) {
-        res.status(404).json({ found: 'Nothing at all!' })
-    }
+  try {
+    const tweets = await tweetPriceChanges();
+    res.status(200).send(tweets);
+  } catch (error) {
+    res.status(404).json({ found: "Nothing at all!" });
+  }
 };

--- a/util/postPriceChangeTweet.js
+++ b/util/postPriceChangeTweet.js
@@ -1,76 +1,103 @@
 /**
  * 1. Grabs recent price changers from MongoDB Collection
- * 2. Loops through and composes Tweet string to be sent only if there are either risers/fallers
- * 3. trycatch attempts tweeting out the string, otherwise catches error
- * TODO: Can I clean this up futher and optimize the execution?
+ * 2. Form tweets, recursively, to allow for threaded tweets,
+ * TODO: Clean up further
  */
 
-import { TwitterApi } from 'twitter-api-v2';
-import { connectToDatabase } from './mongodb'
-
-const {
-  TWITTER_CONSUMER_KEY,
-  TWITTER_CONSUMER_SECRET,
-  TWITTER_ACCESS_TOKEN,
-  TWITTER_ACCESS_TOKEN_SECRET,
-  MONGODB_PRICE_CHANGES_COLLECTION
-} = process.env
+import { TwitterApi } from "twitter-api-v2";
+import { connectToDatabase } from "./mongodb";
 
 const twitterClient = new TwitterApi({
-  appKey: TWITTER_CONSUMER_KEY,
-  appSecret: TWITTER_CONSUMER_SECRET,
-  accessToken: TWITTER_ACCESS_TOKEN,
-  accessSecret: TWITTER_ACCESS_TOKEN_SECRET,
+  appKey: process.env.TWITTER_CONSUMER_KEY,
+  appSecret: process.env.TWITTER_CONSUMER_SECRET,
+  accessToken: process.env.TWITTER_ACCESS_TOKEN,
+  accessSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET
 });
 
 export async function tweetPriceChanges() {
   try {
     const { db } = await connectToDatabase();
 
-    let tweet_string_fallers = ''
-    let tweet_string_risers = ''
-
     // Look up Price Changes Collection by current date, if it returns empty, exit
-    const daily_changes = await db.collection(MONGODB_PRICE_CHANGES_COLLECTION)
+    const daily_changes = await db
+      .collection(process.env.MONGODB_PRICE_CHANGES_COLLECTION)
       .find({
         date: new Date().toDateString()
       })
       .limit(1)
       .sort({ _id: -1 })
-      .toArray()
+      .toArray();
 
-    if (daily_changes.length === 0) return 'No price changes today'
+    if (daily_changes.length === 0) return "No price changes today";
 
-    daily_changes.forEach(dc => {
-      dc.fallers
-        ? dc.fallers
-          .forEach(f => tweet_string_fallers += `\n${f.short_name} - £${(f.new_price / 10).toFixed(1)}m 🔻`)
-        : ''
-      dc.risers
-        ? dc.risers
-          .forEach(r => tweet_string_risers += `\n${r.short_name} - £${(r.new_price / 10).toFixed(1)}m 🔼`)
-        : ''
-    })
+    const { fallers, risers } = daily_changes[0];
+
+    const sort_players = (players) =>
+      players
+        .sort((a, b) => b.new_price - a.new_price)
+        .map(
+          ({ short_name, new_price, old_price }) =>
+            `\n${short_name} - £${(new_price / 10).toFixed(1)}m ${
+              new_price > old_price ? "⬆️" : "🔻"
+            }`
+        );
+
+    const fallers_to_tweet = sort_players(fallers);
+    const risers_to_tweet = sort_players(risers);
+
+    const prefix_length = 58;
+    const tweet_char_limit = 280 - prefix_length;
+
+    const tweeted = [];
+
+    // Function to split into multiple tweets / twitter thread if needed
+    const generate_tweets = (price_movers) => {
+      const combine = (price_movers, current_string = "") => {
+        if (price_movers.length === 0) return [current_string];
+
+        const current_word = price_movers[0];
+        const remaining_words = price_movers.slice(1);
+
+        // If many price movers, we need separate tweets to show them all
+        if (current_string.length + current_word.length <= tweet_char_limit) {
+          const tweet_string = current_string + current_word;
+          const remaining_combinations = combine(remaining_words, tweet_string);
+          return remaining_combinations;
+        } else {
+          return [current_string, ...combine(remaining_words, current_word)];
+        }
+      };
+
+      return combine(price_movers);
+    };
 
     // Send off Price Risers & Fallers, if there's any of them!
-    if (tweet_string_fallers.length > 0) {
-      tweet_string_fallers = '#FPL Price Fallers: \n' + tweet_string_fallers + '\n\n#FPLPriceChanges #FPLCommunity #FPL'
-
-      var tweetedFallers = await twitterClient.v2.tweet({
-        text: tweet_string_fallers,
+    if (fallers_to_tweet.length) {
+      const tweets = generate_tweets(fallers_to_tweet)?.map((item, index) => {
+        return index === 0
+          ? `#FPL Price Fallers: \n${item}\n\n#FPLPriceChanges #FPLCommunity #FPL`
+          : `#FPL Price Fallers (continued): \n${item}\n\n#FPLPriceChanges`;
       });
+
+      const tweeted_fallers = await twitterClient.v2.tweetThread(tweets);
+
+      tweeted.push(tweeted_fallers);
     }
 
-    if (tweet_string_risers.length > 0) {
-      tweet_string_risers = '#FPL Price Risers: \n' + tweet_string_risers + '\n\n#FPLPriceChanges #FPLCommunity #FPL'
-
-      var tweetedRisers = await twitterClient.v2.tweet({
-        text: tweet_string_risers,
+    if (risers_to_tweet.length) {
+      const tweets = generate_tweets(risers_to_tweet)?.map((item, index) => {
+        return index === 0
+          ? `#FPL Price Risers: \n${item}\n\n#FPLPriceChanges #FPLCommunity #FPL`
+          : `#FPL Price Risers (continued): \n${item}\n\n#FPLPriceChanges`;
       });
+
+      const tweeted_risers = await twitterClient.v2.tweetThread(tweets);
+
+      tweeted.push(tweeted_risers);
     }
-    /** TODO: Can I optimize this code to be more efficient? */
-    return [tweetedFallers, tweetedRisers]
+
+    return tweeted;
   } catch (error) {
-    return error
+    return error;
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
-    "github": {
-        "silent": true
-    }
+  "github": {
+    "silent": true
+  },
+  "regions": ["iad1"]
 }


### PR DESCRIPTION
- Allows for threaded tweets in cases where the number of risers / fallers exceed Twitter's single-tweet character limit.
- Try set Vercel functions region to US East in order to reduce needless roundtrip time